### PR TITLE
feat: add internal trusted gRPC listener for hosted-store auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Optional internal gRPC listener via `--internal-addr` that authenticates with a configurable plugin (`--internal-auth-plugin`, default `trust://?allowed=x-organization-id,x-user-id,x-api-key-id`). This lets internal callers such as Substreams tier1 authorize hosted-store requests using forwarded trusted identity headers instead of an end-user JWT (which is consumed upstream and never reaches tier1). Organization scoping via `--organization-id` still applies to the trusted `x-organization-id` header.
+
 ## v0.2.0
 
 ### Added

--- a/cmd/foundational-store/auth.go
+++ b/cmd/foundational-store/auth.go
@@ -12,7 +12,9 @@ import (
 
 func addAuthFlags(cmd *cobra.Command) {
 	cmd.Flags().String("common-auth-plugin", "", "Auth plugin URI (e.g. tgm://auth.staging.thegraph.market); unset disables JWT auth")
-	cmd.Flags().String("organization-id", "", "Reject calls when the JWT organization id does not match this value")
+	cmd.Flags().String("organization-id", "", "Reject calls when the organization id does not match this value")
+	cmd.Flags().String("internal-addr", "", "When set, serve an additional internal listener on this address using --internal-auth-plugin (for internal callers such as Substreams tier1 that forward trusted identity headers instead of an end-user JWT)")
+	cmd.Flags().String("internal-auth-plugin", "trust://?allowed=x-organization-id,x-user-id,x-api-key-id", "Auth plugin URI for the internal listener; the default trust:// plugin trusts the listed forwarded identity headers")
 }
 
 func loadAuthConfig(cmd *cobra.Command, logger *zap.Logger) (grpc.AuthConfig, error) {
@@ -49,4 +51,51 @@ func loadAuthConfig(cmd *cobra.Command, logger *zap.Logger) (grpc.AuthConfig, er
 		Authenticator:  authenticator,
 		OrganizationID: orgID,
 	}, nil
+}
+
+// loadInternalAuthConfig builds the auth config for the optional internal
+// listener. It returns an empty address when --internal-addr is unset, in which
+// case no internal listener should be started.
+//
+// The internal listener typically uses a trust:// plugin so that forwarded
+// identity headers (x-organization-id, x-api-key-id) from internal callers are
+// trusted without an end-user JWT. Organization scoping still applies: when
+// --organization-id is set, the trusted x-organization-id must match it.
+func loadInternalAuthConfig(cmd *cobra.Command, logger *zap.Logger) (cfg grpc.AuthConfig, addr string, err error) {
+	addr, err = cmd.Flags().GetString("internal-addr")
+	if err != nil {
+		return grpc.AuthConfig{}, "", err
+	}
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return grpc.AuthConfig{}, "", nil
+	}
+
+	plugin, err := cmd.Flags().GetString("internal-auth-plugin")
+	if err != nil {
+		return grpc.AuthConfig{}, "", err
+	}
+	plugin = strings.TrimSpace(plugin)
+
+	orgID, err := cmd.Flags().GetString("organization-id")
+	if err != nil {
+		return grpc.AuthConfig{}, "", err
+	}
+	orgID = strings.TrimSpace(orgID)
+
+	if plugin == "" {
+		// Internal listener explicitly running without any auth (local dev).
+		return grpc.AuthConfig{}, addr, nil
+	}
+
+	grpc.RegisterAuthPlugins()
+	authenticator, err := dauth.New(plugin, logger)
+	if err != nil {
+		return grpc.AuthConfig{}, "", fmt.Errorf("initialize internal auth plugin: %w", err)
+	}
+
+	return grpc.AuthConfig{
+		Authenticator:  authenticator,
+		OrganizationID: orgID,
+	}, addr, nil
 }

--- a/cmd/foundational-store/auth.go
+++ b/cmd/foundational-store/auth.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/streamingfast/cli/sflags"
 	"github.com/streamingfast/dauth"
 	"github.com/streamingfast/substreams-foundational-store/grpc"
 	"go.uber.org/zap"
@@ -18,17 +19,8 @@ func addAuthFlags(cmd *cobra.Command) {
 }
 
 func loadAuthConfig(cmd *cobra.Command, logger *zap.Logger) (grpc.AuthConfig, error) {
-	plugin, err := cmd.Flags().GetString("common-auth-plugin")
-	if err != nil {
-		return grpc.AuthConfig{}, err
-	}
-	orgID, err := cmd.Flags().GetString("organization-id")
-	if err != nil {
-		return grpc.AuthConfig{}, err
-	}
-
-	plugin = strings.TrimSpace(plugin)
-	orgID = strings.TrimSpace(orgID)
+	plugin := strings.TrimSpace(sflags.MustGetString(cmd, "common-auth-plugin"))
+	orgID := strings.TrimSpace(sflags.MustGetString(cmd, "organization-id"))
 
 	if plugin == "" {
 		if orgID != "" {
@@ -61,27 +53,14 @@ func loadAuthConfig(cmd *cobra.Command, logger *zap.Logger) (grpc.AuthConfig, er
 // identity headers (x-organization-id, x-api-key-id) from internal callers are
 // trusted without an end-user JWT. Organization scoping still applies: when
 // --organization-id is set, the trusted x-organization-id must match it.
-func loadInternalAuthConfig(cmd *cobra.Command, logger *zap.Logger) (cfg grpc.AuthConfig, addr string, err error) {
-	addr, err = cmd.Flags().GetString("internal-addr")
-	if err != nil {
-		return grpc.AuthConfig{}, "", err
-	}
-	addr = strings.TrimSpace(addr)
+func loadInternalAuthConfig(cmd *cobra.Command, logger *zap.Logger) (grpc.AuthConfig, string, error) {
+	addr := strings.TrimSpace(sflags.MustGetString(cmd, "internal-addr"))
 	if addr == "" {
 		return grpc.AuthConfig{}, "", nil
 	}
 
-	plugin, err := cmd.Flags().GetString("internal-auth-plugin")
-	if err != nil {
-		return grpc.AuthConfig{}, "", err
-	}
-	plugin = strings.TrimSpace(plugin)
-
-	orgID, err := cmd.Flags().GetString("organization-id")
-	if err != nil {
-		return grpc.AuthConfig{}, "", err
-	}
-	orgID = strings.TrimSpace(orgID)
+	plugin := strings.TrimSpace(sflags.MustGetString(cmd, "internal-auth-plugin"))
+	orgID := strings.TrimSpace(sflags.MustGetString(cmd, "organization-id"))
 
 	if plugin == "" {
 		// Internal listener explicitly running without any auth (local dev).

--- a/cmd/foundational-store/remote_feed.go
+++ b/cmd/foundational-store/remote_feed.go
@@ -81,10 +81,20 @@ func remoteFeedCmdE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	internalAuthConfig, internalAddr, err := loadInternalAuthConfig(cmd, zlog)
+	if err != nil {
+		return err
+	}
+
 	app := cli.NewApplication(cmd.Context())
 
 	server := grpc.NewRemoteFeedServer(badgerStore, zlog)
 	app.SuperviseAndStartUsing(server, func() {
+		if internalAddr != "" {
+			zlog.Info("serving public and internal listeners", zap.String("public_addr", serverAddr), zap.String("internal_addr", internalAddr))
+			server.RunWithInternal(serverAddr, authConfig, internalAddr, internalAuthConfig)
+			return
+		}
 		server.Run(serverAddr, authConfig)
 	})
 

--- a/cmd/foundational-store/server.go
+++ b/cmd/foundational-store/server.go
@@ -189,9 +189,19 @@ func serverCmdE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	internalAuthConfig, internalAddr, err := loadInternalAuthConfig(cmd, zlog)
+	if err != nil {
+		return err
+	}
+
 	server := grpc.NewStoreServer(storeImpl, headBlock, zlog)
 
 	app.SuperviseAndStartUsing(server, func() {
+		if internalAddr != "" {
+			zlog.Info("serving public and internal listeners", zap.String("public_addr", serverAddr), zap.String("internal_addr", internalAddr))
+			server.RunWithInternal(serverAddr, authConfig, internalAddr, internalAuthConfig)
+			return
+		}
 		server.Run(serverAddr, authConfig)
 	})
 

--- a/grpc/auth.go
+++ b/grpc/auth.go
@@ -3,11 +3,13 @@ package grpc
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/streamingfast/dauth"
 	dauthgrpc "github.com/streamingfast/dauth/grpc"
 	dauthgrpcmw "github.com/streamingfast/dauth/middleware/grpc"
 	dauthnull "github.com/streamingfast/dauth/null"
+	dauthtrust "github.com/streamingfast/dauth/trust"
 	paymentGatewayAuth "github.com/streamingfast/payment-gateway/auth"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -28,11 +30,23 @@ func (c AuthConfig) Enabled() bool {
 	return c.Authenticator != nil
 }
 
-// RegisterAuthPlugins registers dauth plugins used by foundational-store.
+var registerAuthPluginsOnce sync.Once
+
+// RegisterAuthPlugins registers dauth plugins used by foundational-store. It is
+// safe to call multiple times (public and internal listeners both invoke it).
+//
+// The "trust" plugin is used by the internal listener: it trusts identity
+// headers (e.g. x-organization-id, x-api-key-id) forwarded by internal callers
+// such as Substreams tier1, which authenticate the end user upstream and only
+// propagate the resulting trusted headers (no end-user JWT/api-key reaches the
+// internal hop).
 func RegisterAuthPlugins() {
-	dauthgrpc.Register()
-	dauthnull.Register()
-	paymentGatewayAuth.Register()
+	registerAuthPluginsOnce.Do(func() {
+		dauthgrpc.Register()
+		dauthnull.Register()
+		dauthtrust.Register()
+		paymentGatewayAuth.Register()
+	})
 }
 
 func authUnaryInterceptors(cfg AuthConfig, logger *zap.Logger) []grpc.UnaryServerInterceptor {

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	dgrpcServer "github.com/streamingfast/dgrpc/server"
@@ -25,7 +26,8 @@ type GrpcServer struct {
 	*shutter.Shutter
 	pbservice.UnimplementedStoreServer
 	store            store.Store
-	dgrpcServer      dgrpcServer.Server
+	dgrpcServersLock sync.Mutex
+	dgrpcServers     []dgrpcServer.Server
 	headBlockFetcher FetchHeadBlock
 	readyFunc        CheckReady
 	feedServer       pbfeed.FeedServer
@@ -51,7 +53,6 @@ func NewStoreServer(store store.Store, headBlockFetcher FetchHeadBlock, logger *
 	return &GrpcServer{
 		Shutter:          shutter.New(),
 		store:            store,
-		dgrpcServer:      nil,
 		headBlockFetcher: headBlockFetcher,
 		logger:           logger,
 	}
@@ -64,7 +65,6 @@ func NewRemoteFeedServer(store RemoteFeedStore, logger *zap.Logger) *GrpcServer 
 	return &GrpcServer{
 		Shutter:          shutter.New(),
 		store:            store,
-		dgrpcServer:      nil,
 		headBlockFetcher: func() uint64 { return math.MaxUint64 },
 		readyFunc:        store.IsReady,
 		feedServer:       feed.NewServer(store, logger),
@@ -154,7 +154,28 @@ func (s *GrpcServer) checkReady() (bool, error) {
 	return ready, nil
 }
 
+// Run launches a single listener on addr with the given auth config. It blocks
+// until the underlying gRPC server terminates.
 func (s *GrpcServer) Run(addr string, auth AuthConfig, opts ...grpc.ServerOption) {
+	s.newServer(addr, auth, opts...).Launch(addr)
+}
+
+// RunWithInternal launches the public listener on addr (using auth) plus an
+// internal listener on internalAddr (using internalAuth, typically a trust://
+// plugin that accepts forwarded x-organization-id/x-api-key-id headers from
+// internal callers such as Substreams tier1). Both listeners share the same
+// service handlers and lifecycle. The internal listener runs in its own
+// goroutine; the public listener blocks like Run.
+func (s *GrpcServer) RunWithInternal(addr string, auth AuthConfig, internalAddr string, internalAuth AuthConfig, opts ...grpc.ServerOption) {
+	internal := s.newServer(internalAddr, internalAuth, opts...)
+	go internal.Launch(internalAddr)
+
+	s.newServer(addr, auth, opts...).Launch(addr)
+}
+
+// newServer builds (without launching) a dgrpc server bound to the given auth
+// config, registers it for shutdown tracking, and returns it.
+func (s *GrpcServer) newServer(addr string, auth AuthConfig, opts ...grpc.ServerOption) dgrpcServer.Server {
 	// Create the dgrpc server with reduced per-call logging
 	grpcLogger := s.logger.Named("grpc").WithOptions(zap.IncreaseLevel(zap.WarnLevel))
 	serverOptions := []dgrpcServer.Option{
@@ -168,7 +189,7 @@ func (s *GrpcServer) Run(addr string, auth AuthConfig, opts ...grpc.ServerOption
 	for _, interceptor := range authStreamInterceptors(auth, s.logger) {
 		serverOptions = append(serverOptions, dgrpcServer.WithPostStreamInterceptor(interceptor))
 	}
-	s.dgrpcServer = factory.ServerFromOptions(
+	srv := factory.ServerFromOptions(
 		append(serverOptions,
 			dgrpcServer.WithRegisterService(func(gs *grpc.Server) {
 				pbservice.RegisterStoreServer(gs, s)
@@ -181,11 +202,15 @@ func (s *GrpcServer) Run(addr string, auth AuthConfig, opts ...grpc.ServerOption
 		)...,
 	)
 
-	s.dgrpcServer.OnTerminated(func(err error) {
+	srv.OnTerminated(func(err error) {
 		s.Shutter.Shutdown(err)
 	})
 
-	s.dgrpcServer.Launch(addr)
+	s.dgrpcServersLock.Lock()
+	s.dgrpcServers = append(s.dgrpcServers, srv)
+	s.dgrpcServersLock.Unlock()
+
+	return srv
 }
 
 func healthCheck(ctx context.Context) (isReady bool, out interface{}, err error) {
@@ -203,7 +228,11 @@ func healthCheck(ctx context.Context) (isReady bool, out interface{}, err error)
 }
 
 func (s *GrpcServer) Shutdown(err error) {
-	if server := s.dgrpcServer; server != nil {
+	s.dgrpcServersLock.Lock()
+	servers := s.dgrpcServers
+	s.dgrpcServersLock.Unlock()
+
+	for _, server := range servers {
 		server.Shutdown(15 * time.Second)
 	}
 


### PR DESCRIPTION
## Problem

Hosted foundational stores expose a single auth-enforcing gRPC server, so both the public endpoint (`*.hs.streamingfast.io:443`) and the registry's internal endpoint (`*.hs-internal.streamingfast.io:9000`) require an end-user JWT/api-key. Internal callers such as Substreams tier1 only hold trusted identity headers (the end-user token is authenticated and consumed upstream by the gateway, never reaching tier1). Reads against hosted stores therefore failed with:

```
Unauthenticated: required authorization token not found. Please provide a valid JWT token via 'authorization' header or an API key via 'x-api-key' header
```

tier1 already dials the internal endpoint — the gap is that the internal endpoint runs the same JWT auth as the public one. There was no listener that trusts forwarded identity headers.

## Change

Add an optional internal listener:

- `--internal-addr` — when set, serves an additional gRPC listener sharing the same store handlers.
- `--internal-auth-plugin` — auth plugin for that listener (default `trust://?allowed=x-organization-id,x-user-id,x-api-key-id`).

The `trust://` plugin trusts the forwarded identity headers instead of requiring an end-user JWT. Organization scoping is preserved: with `--organization-id` set, the trusted `x-organization-id` must match. The public listener is unchanged and still enforces JWT/api-key.

Pairs with the substreams tier1 change that forwards `x-organization-id` on hosted-store calls.

## Test

- `go build ./grpc/... ./cmd/...` ✅
- `go test ./grpc/... ./cmd/...` ✅
- `go vet` ✅